### PR TITLE
314 small fixes

### DIFF
--- a/hooks/heading_numbers.py
+++ b/hooks/heading_numbers.py
@@ -63,7 +63,7 @@ def on_config(config):
         # The entire manual lives under the "Home" nav entry in mkdocs.yml.
         # All chapter and appendix sections are direct children of it.
         if label == "Home" and isinstance(value, list):
-            chapter_num = 0
+            chapter_num = 1
             appendix_idx = 0
             for section_item in value:
                 if not isinstance(section_item, dict):
@@ -84,6 +84,8 @@ def on_config(config):
                             # Record the label so on_nav can prefix it in the sidebar.
                             _nav_labels[appendix_label] = letter
                             appendix_idx += 1
+                elif section_label in ['Dedication', 'Acknowledgements', 'Introduction']:
+                    pass
                 else:
                     # Regular chapter — numbered from 0 (Preliminary) upwards.
                     _assign(section_pages, str(chapter_num))

--- a/markdown/acknowledgements/index.md
+++ b/markdown/acknowledgements/index.md
@@ -1,0 +1,30 @@
+---
+title: Acknowledgements
+---
+
+<a id="sec-acknowledgements"></a>
+
+This manual is a result of the combined efforts of many professionals to whom we owe our gratitude.
+
+Contributors to early, formative discussions that informed the basis for our approach include Anna Bohn, Marco Rendina, Rosario López de Prado, Anne-Marie Grapton, Andrea Leigh, and Kelley McGrath.
+
+Many professionals from the FIAF Cataloguing Rules Revision Working Group graciously volunteered their knowledge and experience to the review of this manual.
+A special thanks to Laurent Bismuth, Georg Eckes, and Detlev Balzer for their thoughtful suggestions for improvement.
+We also appreciate Detlev for hosting the FIAF Cataloguing and Documentation Commission (CDC) wiki on his filmstandards.org website.
+
+Several of the illuminating charts and examples, and other formatting needs (such as URLs) were kindly handled by Marian Hausner, Mats Skärstrand, and Miriam Campos-Quinn.
+Marian Hausner also did a painstaking job constructing the bibliography.
+
+This work could not have been done without the support and guidance of the British Film Institute who contributed institutional policies and documents for our use.
+In particular, we want to mention Gabriele Popp, who encouraged and supported BFI staff involvement, and Stephen McConnachie, who generously contributed content and freely gave of his time and knowledge.
+
+We thank current and former members of the CDC, the members of the FIAF Executive Committee, and the FIAF Senior Administrator for their support, especially Christophe Dupin, Rachael Stoeltje, and Olga Futemma.
+
+A very special thank you is owed to Nancy Goldman, who managed numerous steps of the project, such as convening and chairing meetings and guiding the project’s development.
+She also contributed to the authoring of the manual and invested many hours in providing valuable insight and constructive criticism.
+
+Lastly, we are indebted to Linda Tadic, who did a superb job of editing the manual and offered us the wisdom of her expertise, especially in the realm of digital media; and also to designer Lara Denil for all her hard work in improving and transforming the final layout of the manual for publication.
+
+Natasha Fairbairn (Co-author)     
+Maria Assunta Pimpinelli (Co-author ; co-Chair, FIAF Rules Revision)     
+Thelma Ross (Co-author ; co-Chair, FIAF Rules Revision)

--- a/markdown/boundaries/boundaries_between_variants/index.md
+++ b/markdown/boundaries/boundaries_between_variants/index.md
@@ -44,7 +44,11 @@ It is possible for a moving image Variant to be modified in such a way as to cre
 
     Dubbing Studio: Tristar Pictures/Sony Pictures Entertainment
 
-TODO TABLE MISSING HERE.
+| Character | Japanese actor | Tristar Pictures English dub |
+| --- | --- | --- |
+| Godzilla |  Tsutomu Kitagawa | Tsutomu Kitagawa |
+| Yuji Shinoda | Takehiro Murata | Francois Chau |
+| Yuki Ichinose | Naomi Nishida | Denise Iketani |
 
 If much of the original textual and spoken word material remains, most of the original footage remains in roughly the same continuity, however abridged, and substantially most of the contributors are the same, the existence of alterations more often than not constitute a new Variant, rather than a new Work.
 

--- a/markdown/dedication/index.md
+++ b/markdown/dedication/index.md
@@ -1,0 +1,5 @@
+---
+title: Dedication
+---
+
+This manual is dedicated to **Christian Dimitriu** (1945-2016), whose contributions to the field of moving image archiving and FIAF, are immeasurable; and to **Ronny Loewy** (1946-2012), whose knowledge of moving image metadata standards was a primary and crucial source of information during the development of this publication; and to **Laurent Bismuth** (1965-2021), a passionate advocate of CEN 15907 standard whose extensive cataloguing knowledge and expertise and contributions in discussions during the compilation of this publication were invaluable.

--- a/markdown/events/publication/index.md
+++ b/markdown/events/publication/index.md
@@ -1,17 +1,18 @@
 ---
 title: Manifestation Publication Types
 ---
-Release  
-Publication  
-Distribution  
-Broadcast  
-Online Transmission (e.g. Internet, Intranet)  
-Pre-Release  
-Theatrical distribution  
-Non-theatrical distribution  
-Not for release  
-Home video publication  
-Unknown
+
+- Release  
+- Publication  
+- Distribution  
+- Broadcast  
+- Online Transmission (e.g. Internet, Intranet)  
+- Pre-Release  
+- Theatrical distribution  
+- Non-theatrical distribution  
+- Not for release  
+- Home video publication  
+- Unknown
 
 **Publication date**
 
@@ -119,10 +120,10 @@ Selection should be made from a controlled list of values, e.g.:
 
 **Location**
 
-Casting  
-Outdoor shooting  
-Indoor shooting  
-Post-Production  
+- Casting  
+- Outdoor shooting  
+- Indoor shooting  
+- Post-Production  
 
  
 - Location
@@ -222,16 +223,16 @@ Preservation/Restoration Event information consists of the following sub-element
   
 Record the general type of the preservation/restoration activity performed. Selection should be made from a controlled list of terms, which may include:
  
-Conservation / Repair  
-Image Digitisation  
-Sound Digitisation  
-Reconstruction  
-Image Restoration  
-Image Grading  
-Sound Restoration  
-Printing / Recording   
-Duplication   
-Transfer   
+- Conservation / Repair  
+- Image Digitisation  
+- Sound Digitisation  
+- Reconstruction  
+- Image Restoration  
+- Image Grading  
+- Sound Restoration  
+- Printing / Recording   
+- Duplication   
+- Transfer   
 
 - Preservation/Restoration Date
 Record the date or time span in which the preservation/restoration activity was performed. (Dates should be formatted according to ISO 8601 or some other recognised standard.)
@@ -392,4 +393,3 @@ If known and considered of relevance, record the name of the city or smaller geo
 [^3]: EN 15907 6.15 IPR Registration, pp. 23-24
 [^4]: EN 15907, 6.13 Decision event, pp. 26-27
 [^5]: There is no designated separate Restoration Event in EN 15907, and as there can often be an overlap in the types of activity associated with both preservation and restoration, we extended the definition in the 2016 FIAF Moving Image Cataloguing Manual to cover restoring and reconstruction of content too. We have also now referred to it as a Preservation/Restoration Event to increase clarity.
-

--- a/markdown/index.md
+++ b/markdown/index.md
@@ -1,8 +1,6 @@
 ---
-title: Home
+title: The FIAF Moving Image Cataloguing Manual
 ---
-
-## The FIAF Moving Image Cataloguing Manual
 
 The FIAF Moving Image Cataloguing Manual (2016), published by the [FIAF Cataloguing and Documentation Commission (CDC)](https://www.fiafnet.org/pages/Community/Cataloguing-Documentation-Commission.html), is available for free in this online edition.
 

--- a/markdown/introduction/index.md
+++ b/markdown/introduction/index.md
@@ -2,38 +2,8 @@
 title: Introduction
 ---
 
-## Dedication
-This manual is dedicated to **Christian Dimitriu** (1945-2016), whose contributions to the field of moving image archiving and FIAF, are immeasurable; and to **Ronny Loewy** (1946-2012), whose knowledge of moving image metadata standards was a primary and crucial source of information during the development of this publication; and to **Laurent Bismuth** (1965-2021), a passionate advocate of CEN 15907 standard whose extensive cataloguing knowledge and expertise and contributions in discussions during the compilation of this publication were invaluable.
-
-<a id="sec-acknowledgements"></a>
-## Acknowledgements
-This manual is a result of the combined efforts of many professionals to whom we owe our gratitude.
-
-Contributors to early, formative discussions that informed the basis for our approach include Anna Bohn, Marco Rendina, Rosario López de Prado, Anne-Marie Grapton, Andrea Leigh, and Kelley McGrath.
-
-Many professionals from the FIAF Cataloguing Rules Revision Working Group graciously volunteered their knowledge and experience to the review of this manual.
-A special thanks to Laurent Bismuth, Georg Eckes, and Detlev Balzer for their thoughtful suggestions for improvement.
-We also appreciate Detlev for hosting the FIAF Cataloguing and Documentation Commission (CDC) wiki on his filmstandards.org website.
-
-Several of the illuminating charts and examples, and other formatting needs (such as URLs) were kindly handled by Marian Hausner, Mats Skärstrand, and Miriam Campos-Quinn.
-Marian Hausner also did a painstaking job constructing the bibliography.
-
-This work could not have been done without the support and guidance of the British Film Institute who contributed institutional policies and documents for our use.
-In particular, we want to mention Gabriele Popp, who encouraged and supported BFI staff involvement, and Stephen McConnachie, who generously contributed content and freely gave of his time and knowledge.
-
-We thank current and former members of the CDC, the members of the FIAF Executive Committee, and the FIAF Senior Administrator for their support, especially Christophe Dupin, Rachael Stoeltje, and Olga Futemma.
-
-A very special thank you is owed to Nancy Goldman, who managed numerous steps of the project, such as convening and chairing meetings and guiding the project’s development.
-She also contributed to the authoring of the manual and invested many hours in providing valuable insight and constructive criticism.
-
-Lastly, we are indebted to Linda Tadic, who did a superb job of editing the manual and offered us the wisdom of her expertise, especially in the realm of digital media; and also to designer Lara Denil for all her hard work in improving and transforming the final layout of the manual for publication.
-
-Natasha Fairbairn (Co-author)     
-Maria Assunta Pimpinelli (Co-author ; co-Chair, FIAF Rules Revision)     
-Thelma Ross (Co-author ; co-Chair, FIAF Rules Revision)
-
 <a id="sec-introduction"></a>
-## Introduction
+
 The archival moving image field has changed dramatically in recent years, with technological advances revolutionising cataloguing, preservation, and access practices.
 To help cataloguers and archivists respond to these changes, FIAF presents the *FIAF Moving Image Cataloguing Manual (FIAF Manual)*, a revision of the 1991 *FIAF Cataloguing Rules for Film Archives (FIAF Rules)*.
 These new guidelines, created by the FIAF Cataloguing and Documentation Commission and the FIAF Cataloguing Rules Revision Working Group, will help cataloguers create cataloguing or metadata records that will meet requirements of new database technologies and new metadata standards while remaining compatible with older methods and standards.
@@ -83,7 +53,6 @@ While these guidelines are intended to be applicable to all forms of moving imag
 **FRBR-based CEN Terms in Brief**
 
 These guidelines use the terminology of CEN Cinematographic Works Standards for terms reflecting the core structuring of moving image records - namely Work, Variant, Manifestation and Item.
-It is worthwhile providing brief definitions for preliminary guidance here (whilst FRBR is discussed in more depth in [Appendix F.3 Relationship of FIAF Cataloguing Rules to Functional Requirements of Bibliographic Records](#manual-F.3))
 
 *Work*
 
@@ -115,47 +84,51 @@ Functional Requirements for Bibliographic Records (FRBR) was published in 1998 b
 
 FRBR identifies and defines three groups of entities:[^9]
 
-Group 1 (products of intellectual or artistic endeavor)
+- Group 1 (products of intellectual or artistic endeavor)
 
-Work
-Expression
-Manifestation
-Item
-Group 2 (responsible for content, production, or custodianship of Group 1 entities)
+    - Work     
+    - Expression     
+    - Manifestation     
+    - Item 
 
-Person
-Corporate Body
-Group 3 (may serve as subjects of Group 1 entities)
+- Group 2 (responsible for content, production, or custodianship of Group 1 entities)
 
-Group 1 and 2 entities
-Concept
-Object
-Event
-Place
+    - Person     
+    - Corporate Body     
+
+- Group 3 (may serve as subjects of Group 1 entities)
+
+    - Group 1 and 2 entities
+    - Concept
+    - Object
+    - Event
+    - Place
+    
 This manual focuses almost exclusively on the Group 1 entities, their attributes and relationships. Although it also briefly provides guidelines for the description of the Group 2 and Group 3 entities, we recommend the use of other manuals and appropriate existing national or international standards for more detail in these areas.
 
 <a id="sec-existing_standards_for_describing_entities"></a>
 #### Existing standards for describing Entities
 Existing standards for describing Entities include:
 
-RDA
+- RDA
 
-Section 3: Person, Family, & Corporate Body (Chapters 8-11)
-Section 4: Concept, Object, Event & Place (Chapters 12-16)
-Appendix F: Additional Instructions on Names of Persons
-ISAAR (CPF): International Standard Archival Authority Record for Corporate Bodies, Persons and Families, 2nd Edition ([http://www.ica.org/10203/standards/isaar-cpf-international-standard-archival-authority-record-for-corporate-bodies-persons-and-families-2nd-edition.html](http://www.ica.org/10203/standards/isaar-cpf-international-standard-archival-authority-record-for-corporate-bodies-persons-and-families-2nd-edition.html)) - International Council of Archives);
+    - Section 3: Person, Family, & Corporate Body (Chapters 8-11)
+    - Section 4: Concept, Object, Event & Place (Chapters 12-16)
+    - Appendix F: Additional Instructions on Names of Persons
+    
+- ISAAR (CPF): International Standard Archival Authority Record for Corporate Bodies, Persons and Families, 2nd Edition ([http://www.ica.org/10203/standards/isaar-cpf-international-standard-archival-authority-record-for-corporate-bodies-persons-and-families-2nd-edition.html](http://www.ica.org/10203/standards/isaar-cpf-international-standard-archival-authority-record-for-corporate-bodies-persons-and-families-2nd-edition.html)) - International Council of Archives);
 
-EFG Metadata Schema & Vocabularies – 3.6 Agent ([http://www.efgproject.eu/guidelines_and_standards.php](http://www.efgproject.eu/guidelines_and_standards.php))
+- EFG Metadata Schema & Vocabularies – 3.6 Agent ([http://www.efgproject.eu/guidelines_and_standards.php](http://www.efgproject.eu/guidelines_and_standards.php))
 
 Authority files
 
-VIAF (The Virtual International Authority File)
+- VIAF (The Virtual International Authority File)
 
-ISNI (International Standard Name Identifier (ISO 27729) – [http://www.isni.org/](http://www.isni.org/)
+- ISNI (International Standard Name Identifier (ISO 27729) – [http://www.isni.org/](http://www.isni.org/)
 
-IdREf (Identifiants et Référentiels) – [http://www.icacds.org.uk/eng/ISAAR(CPF)2ed.pdf](http://www.icacds.org.uk/eng/ISAAR(CPF)2ed.pdf)
+- IdREf (Identifiants et Référentiels) – [http://www.icacds.org.uk/eng/ISAAR(CPF)2ed.pdf](http://www.icacds.org.uk/eng/ISAAR(CPF)2ed.pdf)
 
-Library of Congress Subject Headings (LCSH) and the Library of Congress Genre-Form Thesaurus (LCGFT)
+- Library of Congress Subject Headings (LCSH) and the Library of Congress Genre-Form Thesaurus (LCGFT)
 
 <a id="sec-definitions_of_the_work_and_variant_entities"></a>
 #### Definitions of the “Work” and ”Variant” Entities
@@ -215,24 +188,21 @@ These user tasks are listed because they are pertinent to moving image catalogui
 
 To find, identify, select, and acquire: [^24]
 
-All the versions (Variants) of a sought Work (for example the various “director’s cuts” of Blade runner as well as the original release version), specified by its title, or by its title in conjunction with the name of one of its creators or by date, that are held by your collection or to which you license access.
+- All the versions (Variants) of a sought Work (for example the various “director’s cuts” of Blade runner as well as the original release version), specified by its title, or by its title in conjunction with the name of one of its creators or by date, that are held by your collection or to which you license access.
 
-All the copies (Manifestations or Items) of a particular version (Variant) of a Work (for example, all the copies you hold of the studio’s director’s cut) that are held by your collection or to which you license access.
+- All the copies (Manifestations or Items) of a particular version (Variant) of a Work (for example, all the copies you hold of the studio’s director’s cut) that are held by your collection or to which you license access.
 
-All the Works of a particular person (for example, director, actor, costume designer) or corporate body (for example, studio) that are held by your collection or to which you license access.
+- All the Works of a particular person (for example, director, actor, costume designer) or corporate body (for example, studio) that are held by your collection or to which you license access.
 
-All the Works on a subject (for example, the Vietnam War) that are held by your collection or to which you license access.
+- All the Works on a subject (for example, the Vietnam War) that are held by your collection or to which you license access.
 
-All the Works in a particular form or genre (for example, animation, gangster films) that are held by your collection or to which you license access.
+- All the Works in a particular form or genre (for example, animation, gangster films) that are held by your collection or to which you license access.
 
-Representation (or, principle of transcription)
+### Representation (or, principle of transcription)
 
 The basic principle of transcription is an area in which archival moving image cataloguing frequently deviates from traditional library cataloguing. Whereas traditional library cataloguers typically transcribe descriptive data directly from the physical item, this is not always the case in archival moving image cataloguing. Because of this, earlier moving image cataloguing rules and standards (FIAF, AMIM) have suggested the term “preferred” rather than “chief” source of filmographic information for representing moving images. The importance of reflecting the original details of a moving image work is a primary principle of organisation for moving image archives. This underlies another practice of moving image cataloguing, which was also recommended in the 1991 FIAF Rules, namely choosing the original release title in country of origin as the preferred title for a work. Other titles (e.g., translated titles, re-release or reissue titles, titles on the item or accompanying material, etc.), are recorded at the appropriate entity level, or designated as belonging to the appropriate entity, and linking mechanisms from other titles to the original release title should be utilised.
 
 Because, however, it is not always possible for a cataloguer to determine an original release title, guidelines are also provided for choice of the preferred title of the work when either: 1) the concept of original release title is not applicable (as in the case of unedited footage), or when 2) a cataloguer is unable, through research, to determine the original release title.
-
-<a id="sec-preliminary_notes"></a>
-## Preliminary Notes
 
 [^1]: FIAF, 1991, p. ix.
 [^2]: Adapted from AMIM2, p.1.
@@ -258,4 +228,3 @@ Because, however, it is not always possible for a cataloguer to determine an ori
 [^22]: Patton, Glenn E. 2009. Functional requirements for authority data: a conceptual model. München: K.G. Saur.
 [^23]: FRBR Final Report, p. 82; RDA, 0.0, Purpose and Scope
 [^24]: Yee, 2007, p. 16.
-

--- a/markdown/items/elements_of_a_moving_image_item/index.md
+++ b/markdown/items/elements_of_a_moving_image_item/index.md
@@ -8,7 +8,7 @@ See “Shallow hierarchy model: 2 levels” in [Elements of description across W
 Ideally the information need only be recorded once irrespective of where in the data structure an institution must place it.
 Therefore guidelines for the treatment of physical/digital description elements are explained fully in the Manifestation chapter.
 
-This chapter contains Item-specific physical/digital description elements beginning at Section 3.1.5 (see [Item Specifics/Extent (e.g. physical/Digital description)](/items/elements_of_a_moving_image_item/#sec-item_specifics_extent).
+This chapter contains Item-specific physical/digital description elements beginning at [Item Specifics/Extent (e.g. physical/Digital description)](/items/elements_of_a_moving_image_item/#sec-item_specifics_extent).
 For example, properties such as Extent and Format at the Manifestation level represent the “ideal,” and item-specific information will capture where it differs from this ideal.
 Only elements that are considered Item-specific have guidelines for the recording of data.
 Physical/digital description elements that are considered Manifestation-specific, but which may be repeated at the Item level, contain hyperlinks to the relevant sections in the Manifestation chapter.
@@ -45,7 +45,8 @@ For example, if a film in the collection is missing the first reel where opening
 
 For creating titles for untitled or unidentified entities see [Supplied/Devised Titles (i.e. Creating titles for untitled/unidentified entities or production material)](/appendices/titles/title_types/#sec-supplied_devised_titles)
 
-For the treatment of Aggregates (e.g. compilations of whole Manifestations) as applied to Items, see Appendix [E.4 Titling of Aggregates] for titling of Aggregates.
+For the treatment of Aggregates (e.g. compilations of whole Manifestations) as applied to Items, see the appendix concerning 
+[Titling of Aggregates](/appendices/aggregates/titling_of_aggregates)
 
 For guidance on wording, order, spelling, punctuation, accentuation and capitalisation, see [Purpose](/preliminary/purpose_scope_and_use/#sec-purpose).
 
@@ -69,20 +70,21 @@ Optionally, if available, record a suitable repository identifier or a registere
 <a id="sec-item_item_element_type"></a>
 ## Item Element Type[^2]
 Record the nature or function of the moving image Item, describing its place in the photochemical or digital production or duplication process. Selection should be made from a controlled list of terms, e.g.:
-Colour Positive
-Colour Negative
-Copper Toned Positive
-Cyan Matrix
-Direct BW Positive
-Original negative
-Duplicate negative
-Positive
-Original positive (reversal film)
-Duplicate positive
-Lavender
-Image negative
-Sound negative
-DCP
+
+- Colour Positive
+- Colour Negative
+- Copper Toned Positive
+- Cyan Matrix
+- Direct BW Positive
+- Original negative
+- Duplicate negative
+- Positive
+- Original positive (reversal film)
+- Duplicate positive
+- Lavender
+- Image negative
+- Sound negative
+- DCP
 
 <a id="sec-item_specifics_extent"></a>
 ## Item Specifics/Extent (e.g. physical/Digital description)
@@ -113,7 +115,7 @@ Re- cording this high-level information will enable simple searching for only fi
 
 Record only if this information is not captured at the Manifestation level or if required at the Item level by the system in use.
 
-A suggested list can be found in [sec:manifest_general_carrier_type](#sec-manifest_general_carrier_type).
+A suggested list can be found in [Manifestation General Media Type](/manifestations/elements_of_a_manifestation/#general-media-type).
 
 For reasons of clarity and to avoid redundancy, optionally, institutions can decide to skip the general media type description for film and video, since it is already implicit in the specific media type.
 
@@ -134,18 +136,18 @@ For optical media, only add commercially produced media here.
 If the optical media is “writable” and is being used to store a digital file, put the digital file format in the gen- eral carrrier type, and the optical storage media in specific media type.
 
 Record the specific carrier type, selecting from a suitable controlled list.
-A suggested list, which is open and not exhaustive, can be found in [sec:manifest_specific_carrier_type](#sec-manifest_specific_carrier_type).
+A suggested list, which is open and not exhaustive, can be found in [Manifestation Specific Media Type](/manifestations/elements_of_a_manifestation/#specific-media-type).
 
 <a id="sec-item_status"></a>
 ### Item Status
 Description of the preservation or access status of the Item. Select term from a controlled list, e.g.  
 
-Master   
-Viewing   
-Accessioned   
-On Loan  
-Status pending   
-Removed
+- Master   
+- Viewing   
+- Accessioned   
+- On Loan  
+- Status pending   
+- Removed
 
 <a id="sec-sound"></a>
 ### Sound
@@ -153,14 +155,15 @@ Technical specifications relating to the fixation of sound in a moving image Man
 This element is for high-level description of sound on the item; i.e., noting whether it has sound, is silent, etc.
 
 Indicate the presence or absence of sound in the Item. Selection should be made from a controlled list of terms, e.g.:
-Sound  
-Silent  
-Mute  
-Combined  
-Combined as Mute  
-Combined as Sound  
-Mixed  
-Temporary 
+
+- Sound  
+- Silent  
+- Mute  
+- Combined  
+- Combined as Mute  
+- Combined as Sound  
+- Mixed  
+- Temporary 
 
 Record only if this information is not captured at the Manifestation level or if required at the Item level by the system in use.
 
@@ -173,12 +176,13 @@ If the Item has sound, note here the track configuration (e.g., mono, stereo, et
 See also [Sound Characteristics of a Manifestation](/manifestations/elements_of_a_manifestation/#sec-sound_characteristics_of_a_manifestation)
 
 Describes the technical or proprietary system used to record the sound on a Item. Select from a controlled list, e.g.:
-Dolby SR
-Dolby Digital
-Mute
-Combined Magnetic Sound
-Combined Optical Sound
-VA RCA Duplex
+
+- Dolby SR
+- Dolby Digital
+- Mute
+- Combined Magnetic Sound
+- Combined Optical Sound
+- VA RCA Duplex
 
 <a id="sec-colour"></a>
 ### Colour
@@ -273,50 +277,50 @@ Selection should be made from a controlled list of terms, e.g.:
 
 **FILM**
 
-Eastman Kodak
-Fuji
-Agfa
+- Eastman Kodak
+- Fuji
+- Agfa
 
 **VIDEO**
 
-3M
-Agfa
-Agfa Gavaert
-Akai
-Ampex
-Ansco
-BASF
-Brifco
-Fuji
-Sony
+- 3M
+- Agfa
+- Agfa Gavaert
+- Akai
+- Ampex
+- Ansco
+- BASF
+- Brifco
+- Fuji
+- Sony
 
 **AUDIO**
 
-Ampex
-Scotch
-3M
-Shamrock
+- Ampex
+- Scotch
+- 3M
+- Shamrock
 
 **OPTICAL**
 
-Maxell
-Memorex
-Philips
-Verbatim
+- Maxell
+- Memorex
+- Philips
+- Verbatim
 
 **DIGITAL TAPE**
 
-Fuji
-HP
-Oracle
-Sony
+- Fuji
+- HP
+- Oracle
+- Sony
 
 **HARD DRIVES**
 
-Hitachi
-Seagate
-Toshiba
-Western Digital
+- Hitachi
+- Seagate
+- Toshiba
+- Western Digital
 
 <a id="sec-stock_batch"></a>
 ### Stock Batch
@@ -395,7 +399,7 @@ These observations should aim to be as clear and concise as possible, avoiding a
 For example, establish whether to use “scratched”, “scratches” or “scratch marks” and be as consistent as possible.
 This enables better searching and accessibility of data.
 
-Record these actions as an Event (see [Events](/items/relationships_of_an_item/#sec-items_events)), with the person or entity performing the action as an Agent (see [sec:items_agents](#sec-items_agents)).
+Record these actions as an Event (see [Events](/items/relationships_of_an_item/#sec-items_events)), with the person or entity performing the action as an [Agent](/items/relationships_of_an_item/).
 
 Ideally, elements covering information and details regarding the condition of an acquired Item would include those listed below.
 
@@ -405,14 +409,14 @@ Record the condition of the Item including its base and/or emulsion and/or perfo
 Selection should be made from a controlled list of terms, for example, “brittle”, “buckled”, “tears,” etc. 
 
 <a id="sec-item_copy_condition_perforations_film"></a>
-## Item Copy Condition Perforations – Film
+#### Item Copy Condition Perforations – Film
 * Foil Patches
 * Torn
 * Pulled
 * Missing
 
 <a id="sec-item_surface_deposit_film_and_video"></a>
-## Item Surface Deposit – Film and Video
+#### Item Surface Deposit – Film and Video
 * Mould
 * Rust
 * Oil deposits
@@ -420,7 +424,7 @@ Selection should be made from a controlled list of terms, for example, “brittl
 * Drying marks
 
 <a id="sec-image_film_and_video"></a>
-## Image – Film and Video
+#### Image – Film and Video
 For film, this relates to the inherent qualities of the Emulsion rather than the physical
 condition of the Emulsion.
 
@@ -435,7 +439,7 @@ For video, refer to AV Artifact Atlas for guidance on terms.
 * Drop-outs
 
 <a id="sec-item_decomposition_film_and_video"></a>
-## Item Decomposition – Film and Video
+#### Item Decomposition – Film and Video
 * Powder
 * Sticky
 * Sticky at head
@@ -448,7 +452,7 @@ As stated above, people or companies performing inspections are Agents.
 Note any indication that the Item is in need of servicing prior to being accessed for use.
 
 <a id="sec-item_location"></a>
-### Item Location
+#### Item Location
 Item descriptions should indicate a storage location number in order to provide access and retrieval.
 Movements and changes of location should also be logged in order to ascertain the precise location of an Item at any given time.
 If possible, use the Item Identifier and Identifier Type fields to note an Item’s location (see [Identifier](/items/elements_of_a_moving_image_item/#sec-item_identifier)).
@@ -466,4 +470,3 @@ Notes for Items are an annotation providing additional information relating spec
 [^5]: RDA 7.17.3 Colour of Moving Image
 [^6]: ISO 8601
 [^7]: Based on RDA 2.20.1.Basic Instructions on Making Notes on Manifestations or Items
-

--- a/markdown/manifestations/attributes_of_a_manifestation/index.md
+++ b/markdown/manifestations/attributes_of_a_manifestation/index.md
@@ -3,7 +3,7 @@ title: Attributes of a Manifestation
 ---
 <a id="sec-manifestation_type"></a>
 ## Manifestation Type
-As mentioned at [INSERT INTERNAL LINK TO BOUNDARIES CHAPTER SECTION], a Manifestation is defined on the basis of two criteria: changes in the publication context and changes in format.
+As mentioned at [Boundaries between Manifestations](/boundaries/boundaries_between_manifestations), a Manifestation is defined on the basis of two criteria: changes in the publication context and changes in format.
 The element Manifestation Type describes the specific type of change.
 
 The Manifestation Type is expressed by a phrase denoting the relationship between the Manifestation and the associated Work/Variant, for example, “pre-release,” “theatrical distribution,” “not for release,” “original,” etc.
@@ -24,7 +24,7 @@ It applies to production material in general, including: original shooting eleme
 
 It may also include, censorship submission prints, working assembly prints, rushes, costume tests, lighting tests, make-up tests, etc. where an institution may need or prefer to group together all production material, i.e. an institution may usually create rushes and tests as separate individual associated records but, where these are acquired as part of a large collection of production material for one particular moving image it prefers, for practical reasons, to keep records together for ease of access or for restoration work purposes.
 
-An institution may create Works in their own right for different in-production filmed aspects, e.g. Screen Tests, Rushes, etc. which are then related to the main, final moving image Work in an associative relationship. Each of these Works would then have their own linked Pre-Release Manifestation. Decisions on this may depend on the quantity and/or nature of materials acquired and an institution's preference. For further details about possibilities and options in structuring and cataloguing production materials and using Pre-release Manifestations see [ADD LINK TO NEW SECTION ON TITLES AND STRUCTURES OF PRODUCTION MATERIALS CURRENTLY BEING EDITED IN BRANCH 259 DOCUMENT OF MANUAL]
+An institution may create Works in their own right for different in-production filmed aspects, e.g. Screen Tests, Rushes, etc. which are then related to the main, final moving image Work in an associative relationship. Each of these Works would then have their own linked Pre-Release Manifestation. Decisions on this may depend on the quantity and/or nature of materials acquired and an institution's preference. For further details about possibilities and options in structuring and cataloguing production materials and using Pre-release Manifestations see [Titles and structuring for production materials](/appendices/titles/title_types/#titles-and-structuring-for-production-materials-including-out-takes-screen-tests-rushes).
 
 Pre-Release Manifestation can also be used with moving images which started production but were never finished and for which footage exists and may have been acquired by an institution.
 
@@ -55,32 +55,16 @@ Detail on the specific nature of the Pre-Release Manifestation (e.g. censorship 
 
 Manifestation Types can represent a unique instance (e.g. the original negative, the first recording/mixing of the sound, censorship cuts, the working assembly edit, etc.) or, more than one instance.
 
-!!! example "Example"
-    Censorship submission print
 
-!!! example "Example"
-    Censorship cuts
-
-!!! example "Example"
-    Make-up tests
-
-!!! example "Example"
-    Costume tests
-
-!!! example "Example"
-    Screen tests general
-
-!!! example "Example"
-    Camera negative
-
-!!! example "Example"
-    Assembly edit
-
-!!! example "Example"
-    Rushes/Dailies
-
-!!! example "Example"
-    Sound mixes
+- Censorship submission print
+- Censorship cuts
+- Make-up tests
+- Costume tests
+- Screen tests general
+- Camera negative
+- Assembly edit
+- Rushes/Dailies
+- Sound mixes
 
 These describe the context, not the format. For example, a censorship print may exist as multiple Items (35mm print, ProRes, MP4)
 
@@ -257,17 +241,14 @@ Some institutions may use this to refer to restorations undertaken by the instit
 
 If required there is the option of creating more than one Restoration Manifestation to group specific outcomes of the project, e.g. a Manifestation for a Demonstration Reel, Raw scans, final digital DCP and DCDM materials resulting from the restoration process, etc. particularly where there may be several Items, or copies, relating to these on different formats.
 
-    Example:
-
 A very ambitious application might result in the following structure, where separate Manifestations are created for different stages of the restoration process with the key categories:
+
 1. Raw Scan: linked to its item source via a Preservation event (type: digitisation).
 2. DCDM (Digital Cinema Distribution Master) and DCP (Digital Cinema Package) under one Manifestation
 3. Blu-ray/DVD - ISO as Manifestations and burned physical discs as a items
 4. Viewing file for internet publication
 
 Each of these Manifestations differs from the others in terms of its technical parameters (e.g., encoding, resolution, compression, file formats), which justifies the separation into different Manifestations.
-
-  Example:
 
 !!! example "Example"
     The great white silence (United Kingdom, Herbert Pointing, 1924) (DVD –Dual Format Edition – BFI) (2010 restoration)

--- a/markdown/manifestations/elements_of_a_manifestation/index.md
+++ b/markdown/manifestations/elements_of_a_manifestation/index.md
@@ -87,7 +87,7 @@ If no language can be determined, the information can be omitted or indicated by
 More than one language can occur in different forms, depending on how the content is expressed: the usage type of the languages defines the form with which the language is expressed, for example, spoken, sung, written, etc.
 
 Record the usage type of a language by taking the most suitable value from a controlled list.
-A suggested list, which is open and not exhaustive, can be found in [Language Usage Types](/works/elements_of_a_work_variant/#sec-languages).[ADD LINK TO SECTION ON LANGUAGE USAGE IN WORKS CHAPTER]
+A suggested list, which is open and not exhaustive, can be found in [Language Usage Types](/works/elements_of_a_work_variant/#sec-languages).
 
 If usage type(s) cannot be determined, indicate a value of “unknown”.
 
@@ -150,12 +150,12 @@ Its description consists of a general media type, which describes the basic prop
 The broad media type of the Manifestation (e.g., film, video, audio, optical, digital file).
 Recording this high-level information will enable simple searching for only film, video, digital, etc. elements rather than searching by all possible formats and carriers. A suggested list, which is open and not exhaustive, can include:
 
-Film
-Video Tape
-Video Disc
-Digital Tape
-Digital Disc
-Digital File
+- Film
+- Video Tape
+- Video Disc
+- Digital Tape
+- Digital Disc
+- Digital File
 
 <a id="sec-manifest_specific_media_type"></a>
 #### Specific Media Type
@@ -209,12 +209,12 @@ Institutions should develop standard lists of terms to indicate the specific car
 
 These are some of the most common terms, but not a complete or definitive list.
 
-LTO5
-LTO6
-T10000D
-HDD (abbreviated for “external hard drive”)
-DVD-R
-Blu-Ray 
+- LTO5
+- LTO6
+- T10000D
+- HDD (abbreviated for “external hard drive”)
+- DVD-R
+- Blu-Ray 
 
 For reasons of clarity and to avoid redundancy, optionally, institutions can decide to skip the general carrier type description, since it is already implicit in the specific carrier type.
 
@@ -266,7 +266,7 @@ A suggested list of examples, which is open and not exhaustive, includes:
 - Letterbox/Widescreen (bars added at the top and bottom) 
 - Windowbox (bars added at the side and the top and bottom) 
 
-Further examples can be found in [INSERT LINK TO FIAF ADVANCED PROJECTION MANUAL HERE]
+Further examples can be found in [The Advanced Projection Manual](https://iupress.org/9782960029611/the-advanced-projection-manual/).
 
 <a id="sec-sound_characteristics_of_a_manifestation"></a>
 ### Sound Characteristics of a Manifestation
@@ -275,26 +275,28 @@ Sound characteristics are technical specifications relating to the placement of 
 Its description consists of a statement about the presence or absence of sound, and optionally, in case of presence, of the description of the method with which the sound has been fixed.
 
 Indicate the presence or absence of sound in the Manifestation. Selection should be made from a controlled list of terms, e.g.:
-Sound  
-Silent  
-Mute  
-Combined  
-Combined as Mute  
-Combined as Sound  
-Mixed  
-Temporary 
+
+- Sound  
+- Silent  
+- Mute  
+- Combined  
+- Combined as Mute  
+- Combined as Sound  
+- Mixed  
+- Temporary 
 
 Optionally, use a flag-type value indicating if the Manifestation includes recorded sound or not (i.e.: has sound: yes/no).
 
 <a id="sec-sound_systems"></a>
 #### Sound Systems
 Describes the technical or proprietary system used to record the sound on a Manifestation. Select from a controlled list, e.g.:
-Dolby SR
-Dolby Digital
-Mute
-Combined Magnetic Sound
-Combined Optical Sound
-VA RCA Duplex
+
+- Dolby SR
+- Dolby Digital
+- Mute
+- Combined Magnetic Sound
+- Combined Optical Sound
+- VA RCA Duplex
 
 <a id="sec-manifest_sound_channel_configuration"></a>
 #### Sound Channel Configuration
@@ -302,11 +304,12 @@ If the Manifestation has sound, note here the track configuration (e.g., mono, s
 Selection should be made from a controlled list of terms.
 
 In case of presence of sound, optionally, if considered relevant, record the name of the physical principle of sound recording. Selection should be made from a controlled list of terms, e.g.:
-Needle sound
-Optical
-Magnetic
-Analogue sound
-Digital
+
+- Needle sound
+- Optical
+- Magnetic
+- Analogue sound
+- Digital
 
 If the Work/Variant associated with the Manifestation in hand had sound originally, but the Manifestation lacks sound, describe it as silent (or mute) and give a note to that effect.[^10]
 
@@ -321,27 +324,29 @@ Colour is also the specific colours, tones, etc. (including black and white) pre
 It consists of a designation of the colour state and, optionally, of the description of the colour system.
 
 Record the colour state of a Manifestation. Selection should be made from a controlled list of terms, e.g.:
-Colour
-Colour + Black & White
-Tinted
-Black and white
-Black and white (tinted)
-Black and white (toned)
-Black and white (tinted and toned)
-Sepia
+
+- Colour
+- Colour + Black & White
+- Tinted
+- Black and white
+- Black and white (tinted)
+- Black and white (toned)
+- Black and white (tinted and toned)
+- Sepia
 
 Optionally, if considered relevant, describe the system or process by which colour is fixed on the carrier or as part of the digital encoding. Selection should be made from a controlled list of terms, e.g.:
-Pathécolor
-Technicolor
-Kinemacolor
-Anscocolor
-Ferraniacolor
-Fujicolor
-Kodachrome
-Eastmancolor
 
-RGB
-YUV
+- Pathécolor
+- Technicolor
+- Kinemacolor
+- Anscocolor
+- Ferraniacolor
+- Fujicolor
+- Kodachrome
+- Eastmancolor
+
+- RGB
+- YUV
 
 <a id="sec-extent_of_a_manifestation"></a>
 ## Extent of a Manifestation[^1]
@@ -364,14 +369,15 @@ For digital Manifestations, there can be two extents: one for the number of file
     A hard-disk stored film in 3 files
 
 Record the number of the logical units of a Manifestation in Arabic numerals, and, if necessary, specify the type of unit. Selection should be made from a controlled list of terms, e.g:
-Reel
-Roll
-Cassette
-Cartridge
-Loop
-Disc
-File
-Digital tape
+
+- Reel
+- Roll
+- Cassette
+- Cartridge
+- Loop
+- Disc
+- File
+- Digital tape
 
 If the number of the logical units of a Manifestation is uncertain, use a question mark following the unit count[^13] or record the uncertain number preceded by “approximately.”[^14]
 
@@ -472,7 +478,7 @@ Notes for Manifestations are annotations providing additional information relati
 
 <a id="sec-date_and_country_of_manifestation"></a>
 ## Date and Country of Manifestation
-Dates and country of Manifestation are not elements of a Manifestation under EN 15907, as in the latter it envisages this data being on linked Publication Events. However, in some systems they may be structured as elements of a Manifestation. For further consideration of this see [ADD internal LINK TO Boundaries between Manifestation Types and Event types section] .
+Dates and country of Manifestation are not elements of a Manifestation under EN 15907, as in the latter it envisages this data being on linked Publication Events. However, in some systems they may be structured as elements of a Manifestation. For further consideration of this see [Boundaries between Manifestations and Events](/boundaries/boundaries_between_manifestations_and_events)
 
 [^1]: Partially based on EN 15907, 6.8 except for the physical components/units number, which is not provided for in the standard.
 [^2]: Based on FIAF 1991, 5.3.4.1, 87.
@@ -492,4 +498,3 @@ Dates and country of Manifestation are not elements of a Manifestation under EN 
 [^16]: Definition of “Stretch frame” taken from: [http://www.nfsa.gov.au/preservation/glossary/stretch-frame](http://www.nfsa.gov.au/preservation/glossary/stretch-frame).
 [^17]: Adapted from FIAF 5.3.4.2.
 [^18]: Based on RDA 2.20.1.Basic Instructions on Making Notes on Manifestations or Items
-

--- a/markdown/preliminary/core_elements_of_description/index.md
+++ b/markdown/preliminary/core_elements_of_description/index.md
@@ -8,19 +8,19 @@ They represent an ideal minimum set of metadata for moving image cataloguing.
 
 | **CORE CONCEPT** | **TOP-LEVEL ELEMENT** | **SUB-ELEMENT** |
 | --- | --- | --- |
-| Title | 1.3.2 Title [Work] | -- |
-| Series / Serial [^2] | 1.3.2 Title [Work] | 1.3.2.1 Title Type = Series/Serial [Work] |
-| Cast | 1.4.1 Agents (e.g. Cast, Credits, Person, Organisation, etc.) [Work] | 1.4.1.1 Agent Activity = Cast [Work] |
-| Credits (including Production Companies) | 1.4.1 Agents [Work] | 1.4.1.1 Agent Activity = Credit (use term for actual role)  [Work] |
-| Country of Reference | 1.3.3 Country of reference [Work] |  |
-| *Original Format | 2.3.4 Format of a moving image Manifestation [Manifestation] | 2.3.4.1.2 Specific Carrier Type: [Manifestation] |
-| *Original Length | 2.3.5 Extent of a Manifestation [Manifestation] | 2.3.5.2 Physical extent of a Manifestation |
-| *Original Duration | 2.3.5 Extent of a Manifestation [Manifestation] | 2.3.5.3 Duration of a Manifestation |
-| *Original Language | 1.3.5 Language(s) [Work] | 1.3.5.1 Language Term + 1.3.5.2 Usage type [Work] |
-| Year of Reference | 1.3.4 Year/Date of reference [Work] | 1.3.4.1 Date Type [Work] |
-| Identifier | As appropriate: 1.3.1 Work/Variant Identifier [Work/Variant] AND/OR 2.3.1 Identifier [Manifestation] AND/OR 3.1.1 Identifier [Item] | As appropriate: 1.3.1.1 Identifier Type [Work/Variant] AND/OR 2.3.1.1 Identifier Type [Manifestation] AND/OR 3.1.1.1 Identifier Type [Item] |
-| Subject/Genre/Form [^3] | 1.4.3 Subject/Genre/Form terms [Work] |  |
-| Content Description | 1.3.6 Content description (synopses, shotlists, etc) |  |
+| Title | Title [Work] | -- |
+| Series / Serial [^2] | Title [Work] | Title Type = Series/Serial [Work] |
+| Cast | Agents (e.g. Cast, Credits, Person, Organisation, etc.) [Work] | Agent Activity = Cast [Work] |
+| Credits (including Production Companies) | Agents [Work] | Agent Activity = Credit (use term for actual role)  [Work] |
+| Country of Reference | Country of reference [Work] |  |
+| *Original Format | Format of a moving image Manifestation [Manifestation] | Specific Carrier Type: [Manifestation] |
+| *Original Length | Extent of a Manifestation [Manifestation] | Physical extent of a Manifestation |
+| *Original Duration | Extent of a Manifestation [Manifestation] | Duration of a Manifestation |
+| *Original Language | Language(s) [Work] | Language Term + Usage type [Work] |
+| Year of Reference | Year/Date of reference [Work] | Date Type [Work] |
+| Identifier | As appropriate: Work/Variant Identifier [Work/Variant] AND/OR Identifier [Manifestation] AND/OR Identifier [Item] | As appropriate: Identifier Type [Work/Variant] AND/OR Identifier Type [Manifestation] AND/OR Identifier Type [Item] |
+| Subject/Genre/Form [^3] | Subject/Genre/Form terms [Work] |  |
+| Content Description | Content description (synopses, shotlists, etc) |  |
 
 The concept of “original” in this manual indicates the first known manifestation of the Work, which is not determined by its release status.
 The concept of “original” must be flexible enough to be applied to released and unreleased Works.
@@ -72,4 +72,3 @@ Properties expressed in one record, with abstracts, contextual and object data s
 [^1]: Adapted from CEN TC 372 EN 15744 element set
 [^2]: EN15744 definitions “A series is a group of separate items related to one another by the fact that each item bears, in addition to its own title, a collective title applying to the group as a whole. A serial is a type of “short subject” work which is characterized principally by the episodic development of a story”. This Core Concept is referencing the name of another Work that a Work may be “part of”, where the latter has been conceived within the context/intention of being an element of a Series or Serial. It is not being used here as a Work/Variant Description Type. (See D.1 Work/Variant Description Types)
 [^3]: Form = Fiction, Non-fiction, etc. Some institutions may incorporate these as a genre term, whilst others may have them as a separate category to genre.
-

--- a/markdown/preliminary/display_issues/index.md
+++ b/markdown/preliminary/display_issues/index.md
@@ -2,7 +2,7 @@
 title: Display issues
 ---
 Although these guidelines are primarily focused on content, many users may also welcome some guidance in data presentation.
-Section 0.4 gathers some of the common display questions with recommendations.
+This section gathers some of the common display questions with recommendations.
 
 <a id="sec-punctuation"></a>
 ## Punctuation
@@ -37,13 +37,13 @@ Alternative practices | ISBD practice
 
 !!! example "Example"
     Die Hard | Die hard    
-
+!!! example "Example"
     Die DREIGROSCHENOPER | Die Dreigroschenoper    
-
+!!! example "Example"
     LES PATTERSON SAVES THE WORLD | Les Patterson saves the world     
-
+!!! example "Example"
     Les MISERABLES | Les miserables    
-
+!!! example "Example"
     American in Paris, An | An American in Paris
 
 MARC21 tag
@@ -53,4 +53,3 @@ MARC21 tag
 
 [^1]: [http://www.ifla.org/files/assets/cataloguing/isbd/isbd-cons_20110321.pdf](http://www.ifla.org/files/assets/cataloguing/isbd/isbd-cons_20110321.pdf)
 [^2]: [http://www.fiafnet.org/~fiafnet/uk/publications/fep_cataloguingRules.html](http://www.fiafnet.org/~fiafnet/uk/publications/fep_cataloguingRules.html)
-

--- a/markdown/preliminary/prelim_sources_of_information/index.md
+++ b/markdown/preliminary/prelim_sources_of_information/index.md
@@ -57,7 +57,7 @@ In instances where Primary source data relating to on-screen titles and credits,
 !!! example "Example"
     Il vangelo secondo Matteo (Italy, 1964)
 
-Work History note: The credits in the opening titles on actual prints of the film give 'Alessandro Clerici' as playing the role of Pontius Pilate. However, he was in fact played by Alessandro Tasca (aka Alessandro Tasca di Cutò). Verified by his daughter Ama Tasca di Cutò in correspondence with the BFI (February 2020)  and further researched by the BFI in conjunction with Cineteca Bologna. Alessandro Tasca also discusses his taking on the role of Pilate in Pasolini's film, and his fee for the day's work, in correspondence with Orson Welles (housed at the University of Michigan). Distribution information from c.1964/65 from UniItalia in Rome and from other English distribution companies of the film in the 1960s also cite 'Alessandro Tasca' as the credit for Pontius Pilate.
+    Work History note: The credits in the opening titles on actual prints of the film give 'Alessandro Clerici' as playing the role of Pontius Pilate. However, he was in fact played by Alessandro Tasca (aka Alessandro Tasca di Cutò). Verified by his daughter Ama Tasca di Cutò in correspondence with the BFI (February 2020)  and further researched by the BFI in conjunction with Cineteca Bologna. Alessandro Tasca also discusses his taking on the role of Pilate in Pasolini's film, and his fee for the day's work, in correspondence with Orson Welles (housed at the University of Michigan). Distribution information from c.1964/65 from UniItalia in Rome and from other English distribution companies of the film in the 1960s also cite 'Alessandro Tasca' as the credit for Pontius Pilate.
 
 [^1]: Based on RDA 2.2.4 Other Sources of Information
 [^2]: RDA 2.20.2.3 Title Source
@@ -68,4 +68,3 @@ Work History note: The credits in the opening titles on actual prints of the fil
 [^7]: RDA 2.2.4 Other Sources of Information
 [^8]: RDA 2.2.4 Other Sources of Information
 [^9]: See the name note on the [BFI record for Richard Greene](https://collections-search.bfi.org.uk/web/Details/People/177651)
-

--- a/markdown/works/attributes_of_a_moving_image_work_variant/index.md
+++ b/markdown/works/attributes_of_a_moving_image_work_variant/index.md
@@ -10,30 +10,24 @@ For example, a television series could be catalogued as a Serial, which implies 
 Record the level of description of the work being catalogued, for example, “analytic,” “monographic,” “serial,” etc., according to a controlled vocabulary.
 The terms used in this Manual are derived from traditional bibliographic cataloguing rules and from EN 15907, but an institution may choose to create its own list of terms.
 
-The Types below reflect terms used in Section 4.1.2 Attributes in the CEN standard EN 15907. (INSERT LINK TO EN 15907 IN A FOOTNOTE along with "The terms and their definitions used in the EN 15907 Standard itself are rooted in those from UNESCO CCF/B (Common Communications Format / Bibliographic, UNESCO PGI-92/WS/9, Paris, 1992,(INSERT LINK) which related to bibliographic information.)
+The Types below reflect terms used in Section 4.1.2 Attributes in the CEN standard EN 15907. [^2] 
 
 ### Analytic (component part)
 Content that is contained in another content.
 A component part may itself be either monographic or serial. Component here means intentional component part not fragments or excerpts of a moving image, e.g. an individual element from a larger newsreel issue.
-
-Examples:
 
 !!! example "Example"
     Work [Monographic] – Topical Budget 657-1 
 
     Manifestation: Theatrical Release - 35mm - UK - 27th March 1924
 
-
     Work [Analytic (component part)] – One way of solving the traffic problem 
 
     Manifestation 1: Internet – digital file – UK -2015 – BFIplayer (streaming channel) 
 
-
-
 !!! example "Example"
     Work [Monographic] - Kwaidan
     Manifestation: Theatrical Release - 35mm - Japan - December 1964
-
 
     Work [Analytic (component part)] - The woman of the snow
     Manifestation: Theatrical Release - 35mm - United Kingdom - October 1968 
@@ -48,7 +42,7 @@ The record for the television series itself is catalogued as a Serial.
 
 !!! example "Example"
     Coronation Street [1960-12-09] 
-
+!!! example "Example"
     Spaced. Series 1 Episode 1. 1999-09-02
 
 ### Serial
@@ -57,40 +51,40 @@ A Work record for a television series is catalogued as a “Serial.” Individua
 
 !!! example "Example"
     Gaumont British News (1934-) 
-
+!!! example "Example"
     Flash Gordon’s Trip to Mars (1938) 
-
+!!! example "Example"
     Chemistry Essentials (1996) 
-
+!!! example "Example"
     Breaking Bad (2008-01-20 – 2013-09-29)
 
 ### Collection
-Content issued in several independent parts; an ‘umbrella’ work title covering a number of different Works/Variants/Manifestations[^2].
+Content issued in several independent parts; an ‘umbrella’ work title covering a number of different Works/Variants/Manifestations[^3].
 
 !!! example "Example"
     Pleasure (Joan Littlewood, c1963) (Footage shot on behalf of Joan Littlewood as part of her ‘Fun Palace’ project.) 
-
+!!! example "Example"
     The ‘Dogme’ films (Each individually numbered.) 
-
+!!! example "Example"
     Shadows of progress: documentary film in post-war Britain 1951-1977
 
-Other uses for Collection:[^3]
+Other uses for Collection:[^4]
 
 Archive-acquired collections of works not originally intended for general release or broadcast all have component parts that form the collection as a whole, usually acquired on a series of numerous film reels or videotapes, etc. each with an identifying title.
 
 !!! example "Example"
     David Lean home movies 
-
+!!! example "Example"
     William Butlin personal films 
-
+!!! example "Example"
     Hollywood interviews (unedited production material for series Hollywood) 
-
+!!! example "Example"
     BFI London Film Festival Awards 2010 – production material, etc. 
-
+!!! example "Example"
     Fifties features (videotape collection of production material, with each of the tapes given an identifying acquisition title: 
-
+!!! example "Example"
     B1-3 Sylvia Syms I/V 
-
+!!! example "Example"
     B4-6 Sylvia Syms I/V & Jill Craigie I/V 
 
 
@@ -100,11 +94,11 @@ The individual components of this collection would also be created as individual
 
 !!! example "Example"
     Egypt 
-
+!!! example "Example"
     India 
-
+!!! example "Example"
     India no.2 
-
+!!! example "Example"
     Kenya
 
 These titles should then be linked to the collection-level description and assigned “part of” relationship.
@@ -118,6 +112,6 @@ Aggregate compilation videos/DVDs that are collections of individual works exist
 Provide a list of the compiled works contained in the Collections Work in its Synopsis or Summary field.
 
 [^1]: EN 15907, 4.1.2 Attributes—description Level, p. 8; BFI CID Stylistics Manual, A.1.3 Filmographic Level, pp. 7-8
-[^2]: This aligns with EN 15907 definitions relating to Work types and is different and distinct from Collection Aggregates
-[^3]: BFI CID Stylistics Manual, A.1.3 Filmographic Level, p. 8
-
+[^2]: https://filmstandards.org/fsc/index.php/EN_15907. The terms and their definitions used in the EN 15907 Standard itself are rooted in those from UNESCO CCF/B (Common Communications Format / Bibliographic, UNESCO PGI-92/WS/9, Paris, 1992,(INSERT LINK) which related to bibliographic information.)
+[^3]: This aligns with EN 15907 definitions relating to Work types and is different and distinct from Collection Aggregates
+[^4]: BFI CID Stylistics Manual, A.1.3 Filmographic Level, p. 8

--- a/markdown/works/elements_of_a_work_variant/index.md
+++ b/markdown/works/elements_of_a_work_variant/index.md
@@ -35,12 +35,13 @@ Use what makes sense for your institution; there is no recommendation for one pa
 However, it is recommended that at least one unique identifier be included in the record.
 It is critical that each Identifier be unique.
 
-*Pietro Fosco is the pseudonym of Giovanni Pastrone used in the ISAN registration.*
 
 !!! example "Example"
     Cabiria (Italy, 1914, Piero Fosco)  
 
     Work identifier – ISAN number: ISAN 0000-0000-7B37-0000-J-0000-0000-H
+
+    Note: Pietro Fosco is the pseudonym of Giovanni Pastrone used in the ISAN registration.
 
 !!! example "Example"
     Volver (Spain, 2006, Pedro Almodovar)  
@@ -197,7 +198,7 @@ b) Retain the old geo-political countries which relate to or are given in the fi
 
 c) Where countries have attained independence from former empires, multinational states or unions, earlier films made by production companies/studios in the same geographical areas of the countries concerned may be culturally and linguistically a part of their heritage, or there is a need or desire for an institution to identify such films distinct from those in other areas of the same empire or union. e.g. Ukraine. Thus, Ukraine could be added as an additional country to films made during the times it was part of the Russian Empire or USSR. In that case add Ukraine as an additional country, preferably as an ISO code ([https://www.iso.org/obp/ui/#iso:code:3166:UA](https://www.iso.org/obp/ui/#iso:code:3166:UA)). Under ISO this technically pertains to the country post-1991, with use of the Soviet Union/USSR before then. Under LC/MARC though, country Ukraine “covers both the Ukrainian SSR (1917-Aug.24 1991) and the newly independent Ukraine (25 Aug. 1991- )”. [It should be noted that 1917 is historically inaccurate: The Ukrainian SSR was established only in 1919].
 
-d) Alternatively create a country for the Ukrainian SSR, Georgian SSR, Armenian SSR, etc. and apply those as additional production countries. Sometimes these Soviet Socialist Republics (SSRs) existed independently until joining together to form the USSR in 1922, and it may be relevant to just use these as production country for any films made between 1918 and 1922. However, there are no ISO codes for separate Soviet Socialist republics except for Byelorussian SSR. [ADD FOOTNOTE: SSRs were often officially formed on different dates between 1918 and the 1930s, and there were also often subsequent boundary changes between them. For further exploration of this see ADD LINK TO CDC FIAF website Ukraine document if latter has been enhanced with additional details]
+d) Alternatively create a country for the Ukrainian SSR, Georgian SSR, Armenian SSR, etc. and apply those as additional production countries. Sometimes these Soviet Socialist Republics (SSRs) existed independently until joining together to form the USSR in 1922, and it may be relevant to just use these as production country for any films made between 1918 and 1922. However, there are no ISO codes for separate Soviet Socialist republics except for Byelorussian SSR. [^200]
 
 e) Combinations of any of the above.
 
@@ -446,13 +447,13 @@ Information on the provenance of the specific Items in an archive’s collection
 ### Censorship History
 Document information related to the censorship history of a Work/Variant, including:[^16]
 
-*Any events in which a Manifestation/Item of a Work/Variant was evaluated by a censorship body or an accredited rating agency.* 
+- Any events in which a Manifestation/Item of a Work/Variant was evaluated by a censorship body or an accredited rating agency.
 
-*The geographic region for which the verdict is (was) valid.*
+- The geographic region for which the verdict is (was) valid.
 
-*Any identifier issued by the agency uniquely identifying the act of rating or censorship and associated documents such as censorship visa or rating certificates.*
+- Any identifier issued by the agency uniquely identifying the act of rating or censorship and associated documents such as censorship visa or rating certificates.
 
-*The outcome of the act of rating or censorship.*
+- The outcome of the act of rating or censorship.
 
 !!! example "Example"
     À bout de souffle (France, 1960, Jean-Luc Godard) 
@@ -500,6 +501,7 @@ According to the 2004 law, the biggest part of the cast and crew, the locations,
 [^3]: The first of these was the formula followed by the British Film Institute. BFI CID Stylistics Manual – 2nd Edition. A.8.1., which subsequently changed to using a country of reference ordering based more on the on-screen ordering of production companies. CID Cataloguing Manual|Moving Image Catalogue (revised 2022). F.4 and F.4.1.
 [^4]: http://www.iso.org/iso/home/standards/country_codes.htm
 [^5]: ISO 3166-3 Codes for the representation of names of countries and their subdivisions -- Part 3: Code for formerly used names of countries, is available for purchase as a PDF on the ISO website: [http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=2130](http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=2130)
+[^200]: SSRs were often officially formed on different dates between 1918 and the 1930s, and there were also often subsequent boundary changes between them. For further exploration of this see ADD LINK TO CDC FIAF website Ukraine document if latter has been enhanced with additional details
 [^6]: EN 15907, 6.6 Year of Reference, p. 20
 [^7]: Irish Film Archive, p. 13.
 [^8]: FIAF, 3.5.4, p. 64

--- a/markdown/works/index.md
+++ b/markdown/works/index.md
@@ -3,7 +3,7 @@ title: Moving Image Works
 ---
 <a id="sec-moving_image_works_definition"></a>
 ## Definitions[^1]
-Brief definitions of the standard CEN terms Work/Variant/Manifestation/Item used in the Manual were provided at the end of the Introduction (see [Introduction](/preliminary/#sec-introduction)).
+Brief definitions of the standard CEN terms Work/Variant/Manifestation/Item used in the Manual were provided at the end of the Introduction (see [Introduction](/introduction)).
 This and the following sections provide in-depth definitions of the terms as used in these guidelines, beginning with the highest level in the description hierarchy: Moving Image Work.
 
 <a id="sec-moving_image_work"></a>
@@ -76,4 +76,3 @@ Works include:
 [^4]: Adapted from the definition of a Cinematographic Work in EN 15907, 4.1.1, p.8.
 [^5]: Adapted from the definition of a Cinematographic Work in EN 15907, 4.1.1, p.8.
 [^6]: These are invented examples for illustrative purposes
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,9 +65,13 @@ plugins:
 nav:
   - Home:
     - index.md
+    - Dedication:
+      - dedication/index.md
+    - Acknowledgements:
+      - acknowledgements/index.md
+    - Introduction:
+      - introduction/index.md
     - Preliminary:
-      - Introduction:
-        - preliminary/introduction/index.md
       - Purpose, Scope, and Use:
         - preliminary/purpose_scope_and_use/index.md
       - Core Elements of Description:


### PR DESCRIPTION
A collection of small changes, including some link fixes. The most significant changes are splitting the Dedication, Acknowledgements and Introduction into their own pages to more closely mirror the source structure. Also, @heftberger and @natashafairbairn, for value lists I have inserted bullet points, so 

- Release  
- Publication  
- Distribution  
- Broadcast 

instead of: Release, Publication, Distribution, Broadcast 

Let me know if this is the right presentation, and I am correcting something which was lost in the conversion process, not that you had made a conscious decision that the example value lists should just be part of the main body of the respective texts?
